### PR TITLE
Fix issue w/ data.size is not a function

### DIFF
--- a/lib/docsize_cache.js
+++ b/lib/docsize_cache.js
@@ -16,7 +16,7 @@ DocSzCache.prototype.setPcpu = function (pcpu) {
 DocSzCache.prototype.getSize = function (coll, query, opts, data) {
   // If the dataset is null or empty we can't calculate the size
   // Do not process this data and return 0 as the document size.
-  if (!(data && (data.length || (data.size && data.size())))) {
+  if (!(data && (data.length || data.size))) {
     return 0;
   }
 


### PR DESCRIPTION
Fixes an issue in docsize_cache.js#19 where the data parameter can be either an Array or a Map, and a Map's size property is a number and not a function.

https://github.com/meteor/meteor-apm-agent/pull/12/commits/0ce90f5c36c74c4f46bc9da35b1bfab6f07858b0