### PR TITLE
Remove usage of deprecated API

### DIFF
--- a/lib/hijack/meteorx.js
+++ b/lib/hijack/meteorx.js
@@ -10,7 +10,7 @@ function getSession() {
     headers: []
   };
 
-  const server = Meteor.default_server;
+  const server = Meteor.server;
 
   server._handleConnect(fakeSocket, {
     msg: "connect",

--- a/lib/hijack/wrap_session.js
+++ b/lib/hijack/wrap_session.js
@@ -144,8 +144,8 @@ wrapSession = function(sessionProto) {
 };
 
 // wrap existing method handlers for capturing errors
-_.each(Meteor.default_server.method_handlers, function(handler, name) {
-  wrapMethodHanderForErrors(name, handler, Meteor.default_server.method_handlers);
+_.each(Meteor.server.method_handlers, function(handler, name) {
+  wrapMethodHanderForErrors(name, handler, Meteor.server.method_handlers);
 });
 
 // wrap future method handlers for capturing errors

--- a/lib/models/pubsub.js
+++ b/lib/models/pubsub.js
@@ -162,8 +162,8 @@ PubsubModel.prototype._getSubscriptionInfo = function() {
   var totalObservers = {};
   var cachedObservers = {};
 
-  for(var sessionId in Meteor.default_server.sessions) {
-    var session = Meteor.default_server.sessions[sessionId];
+  for(var sessionId in Meteor.server.sessions) {
+    var session = Meteor.server.sessions[sessionId];
     _.each(session._namedSubs, countSubData);
     _.each(session._universalSubs, countSubData);
   }
@@ -261,7 +261,7 @@ PubsubModel.prototype.incrementHandleCount = function(trace, isCached) {
   var publicationName = this._getPublicationName(trace.name);
   var publication = this._getMetrics(timestamp, publicationName);
 
-  var session = Meteor.default_server.sessions[trace.session];
+  var session = Meteor.server.sessions[trace.session];
   if(session) {
     var sub = session._namedSubs[trace.id];
     if(sub) {

--- a/lib/models/system.js
+++ b/lib/models/system.js
@@ -21,7 +21,7 @@ SystemModel.prototype.buildPayload = function() {
   metrics.startTime = Kadira.syncedDate.syncTime(this.startTime);
   metrics.endTime = Kadira.syncedDate.syncTime(now);
 
-  metrics.sessions = _.keys(Meteor.default_server.sessions).length;
+  metrics.sessions = _.keys(Meteor.server.sessions).length;
   metrics.memory = process.memoryUsage().rss / (1024*1024);
   metrics.newSessions = this.newSessions;
   this.newSessions = 0;

--- a/package.js
+++ b/package.js
@@ -18,12 +18,12 @@ var npmModules = {
 
 Npm.depends(npmModules);
 
-Package.on_use(function (api) {
+Package.onUse(function (api) {
   configurePackage(api);
   api.export(['Kadira']);
 });
 
-Package.on_test(function (api) {
+Package.onTest(function (api) {
   configurePackage(api);
   api.use([
     'tinytest',
@@ -31,12 +31,12 @@ Package.on_test(function (api) {
   ], ['client', 'server']);
 
   // common before
-  api.add_files([
+  api.addFiles([
     'tests/models/base_error.js'
   ], ['client', 'server']);
 
   // common server
-  api.add_files([
+  api.addFiles([
     'tests/utils.js',
     'tests/ntp.js',
     'tests/jobs.js',
@@ -69,7 +69,7 @@ Package.on_test(function (api) {
   ], 'server');
 
   // common client
-  api.add_files([
+  api.addFiles([
     'tests/client/utils.js',
     'tests/client/error_tracking.js',
     'tests/client/models/error.js',
@@ -79,7 +79,7 @@ Package.on_test(function (api) {
   ], 'client');
 
   // common after
-  api.add_files([
+  api.addFiles([
     'tests/common/default_error_filters.js',
     'tests/common/send.js'
   ], ['client', 'server']);
@@ -108,13 +108,13 @@ function configurePackage(api) {
   api.use(['underscore', 'random', 'jquery@1.11.11', 'localstorage'], ['client']);
 
   // common before
-  api.add_files([
+  api.addFiles([
     'lib/common/unify.js',
     'lib/models/base_error.js'
   ], ['client', 'server']);
 
   // only server
-  api.add_files([
+  api.addFiles([
     'lib/jobs.js',
     'lib/retry.js',
     'lib/utils.js',
@@ -149,7 +149,7 @@ function configurePackage(api) {
   ], 'server');
 
   // only client
-  api.add_files([
+  api.addFiles([
     'lib/retry.js',
     'lib/ntp.js',
     'lib/client/utils.js',
@@ -160,7 +160,7 @@ function configurePackage(api) {
     'lib/client/kadira.js'
   ], 'client');
 
-  api.add_files([
+  api.addFiles([
     // It's possible to remove this file after some since this just contains
     // a notice to the user.
     // Actual implementation is in the meteorhacks:kadira-profiler package
@@ -168,7 +168,7 @@ function configurePackage(api) {
   ], 'client');
 
   // common after
-  api.add_files([
+  api.addFiles([
     'lib/common/default_error_filters.js',
     'lib/common/send.js'
   ], ['client', 'server']);

--- a/tests/_helpers/helpers.js
+++ b/tests/_helpers/helpers.js
@@ -124,7 +124,7 @@ CloseClient = function(client) {
   client.disconnect();
   var f = new Future();
   function checkClientExtence(sessionId) {
-    var sessionExists = Meteor.default_server.sessions[sessionId];
+    var sessionExists = Meteor.server.sessions[sessionId];
     if(sessionExists) {
       setTimeout(function() {
         checkClientExtence(sessionId);

--- a/tests/models/system.js
+++ b/tests/models/system.js
@@ -160,6 +160,6 @@ function sendConnectMessage (options) {
     socket.headers['x-forwarded-for'] = options.forwardedAddress;
   if(options.sessionId)
     message.session = options.sessionId;
-  Meteor.default_server._handleConnect(socket, message);
+  Meteor.server._handleConnect(socket, message);
   return socket._meteorSession;
 }


### PR DESCRIPTION
APM uses API that has been deprecated since Meteor 1.0 and is finally being removed in Meteor 2.3. This PR removes the deprecated API

https://github.com/meteor/meteor-apm-agent/commit/f1d7fb685adeed93071e42148ea0e02560909445